### PR TITLE
Use GuildTextChannels instead of TextChannels 

### DIFF
--- a/libs/GuildVoiceChannel.lua
+++ b/libs/GuildVoiceChannel.lua
@@ -1,38 +1,38 @@
 --[=[
-@c GuildVoiceChannel x GuildChannel x TextChannel
+@c GuildVoiceChannel x GuildChannel x GuildTextChannel
 @d Represents a voice channel in a Discord guild, where guild members can connect
 and communicate via voice chat.
 ]=]
 
 local discordia = require('discordia')
 
-local TextChannel = discordia.class.classes.TextChannel
+local GuildTextChannel = discordia.class.classes.GuildTextChannel
 local GuildChannel = discordia.class.classes.GuildChannel
 
 local GuildVoiceChannel = discordia.class.classes.GuildVoiceChannel
 local get = GuildVoiceChannel.__getters
 
-GuildVoiceChannel.__bases[#GuildVoiceChannel.__bases + 1] = TextChannel
+GuildVoiceChannel.__bases[#GuildVoiceChannel.__bases + 1] = GuildTextChannel
 
 local blacklist = {getPinnedMessages = true}
 
 function GuildVoiceChannel:__init(data, parent)
 	GuildChannel.__init(self, data, parent)
-	TextChannel.__init(self, data, parent)
+	GuildTextChannel.__init(self, data, parent)
 end
 
 function GuildVoiceChannel:_load(data)
 	GuildChannel._load(self, data)
-	TextChannel._load(self, data)
+	GuildTextChannel._load(self, data)
 end
 
-for name, method in pairs(TextChannel) do
+for name, method in pairs(GuildTextChannel) do
 	if not blacklist[name] then
 		GuildVoiceChannel[name] = method
 	end
 end
 
-for name, getter in pairs(TextChannel.__getters) do
+for name, getter in pairs(GuildTextChannel.__getters) do
 	get[name] = getter
 end
 


### PR DESCRIPTION
I added this to my bot to which my statistic voice channels stopped updating and started erroring (no setName function), when I made it inherit from GuildTextChannel instead it got fixed